### PR TITLE
Destacar contenido original

### DIFF
--- a/Memoria/capitulos/0-Metodologia/Comentarios_previos.tex
+++ b/Memoria/capitulos/0-Metodologia/Comentarios_previos.tex
@@ -21,3 +21,9 @@ Para ello se ha acompañado la exposición con notas en los márgenes aclaratori
 
 %Nota los colores seleccionados han sido creados con una paleta inclusiva
 % https://palett.es/6a94a8-013e3b-7eb645-31d331-26f27d
+
+Además a lo largo del trabajo se han realizado aportaciones propias y resultados novedosos, estos aparecerán destacados de la siguiente forma: 
+
+\begin{aportacionOriginal}
+    Este recuadro representa cómo se indicará de ahora en adelante alguna aportación original a la materia. 
+\end{aportacionOriginal}

--- a/Memoria/capitulos/1-Introduccion_redes_neuronales/feedforward-network-una-capa.tex
+++ b/Memoria/capitulos/1-Introduccion_redes_neuronales/feedforward-network-una-capa.tex
@@ -42,24 +42,27 @@ De acorde con nuestra filosofía de trabajo expuesta en la introducción del cap
     \caption{\textit{Grafo} de una red neuronal de una capa oculta}
     \label{img:grafo-red-neuronal-una-capa-oculta}
 \end{figure}
-
-\begin{definicion}[Redes neuronales de una capa oculta] \label{definition:redes_neuronales_una_capa_oculta}
-    Dados $X \subseteq \R^d, Y \subseteq \R^s$ y  $\Gamma$ un conjunto no vacío de funciones medibles definidas de $\R$ a $\R$, denotaremos como 
-    \begin{align}
-        \mathcal{H}(X,Y) 
-        =
-        \{
-            h : X \longrightarrow Y 
-            /& \quad 
-            h_k(x) = 
-            \sum_{i=1}^{n} \beta_{i k} \gamma_{i}( A_{i}(x)), \\
-            & \text{donde  $h_k$  es la proyección k-ésima de $h$ con 
-            $k \in \{1, \ldots, s\}$}, \\
-            & n \in \N,\gamma_{i} \in \Gamma , \beta_{i k} \in \R
-             \text{ y }A_{i} \text{ una aplicación afín de $\R^d$ a $\R$}           
-        \}.
-    \end{align}
-\end{definicion}
+%\begin{mdframed} % Añadimos símbolo de que es contenido
+    \begin{aportacionOriginal}
+    \begin{definicion}[Redes neuronales de una capa oculta] \label{definition:redes_neuronales_una_capa_oculta}
+        Dados $X \subseteq \R^d, Y \subseteq \R^s$ y  $\Gamma$ un conjunto no vacío de funciones medibles definidas de $\R$ a $\R$, denotaremos como 
+        \begin{align}
+            \mathcal{H}(X,Y) 
+            =
+            \{
+                h : X \longrightarrow Y 
+                /& \quad 
+                h_k(x) = 
+                \sum_{i=1}^{n} \beta_{i k} \gamma_{i}( A_{i}(x)), \\
+                & \text{donde  $h_k$  es la proyección k-ésima de $h$ con 
+                $k \in \{1, \ldots, s\}$}, \\
+                & n \in \N,\gamma_{i} \in \Gamma , \beta_{i k} \in \R
+                \text{ y }A_{i} \text{ una aplicación afín de $\R^d$ a $\R$}           
+            \}.
+        \end{align}
+    \end{definicion}
+\end{aportacionOriginal}
+%\end{mdframed}
 % Nota margen aclarativa de la fórmula
 \marginpar{\maginLetterSize
     \iconoAclaraciones \textcolor{dark_green}{     

--- a/Memoria/capitulos/2-Articulo_rrnn_aproximadores_universales/desgranando_el_articulo/articulo_2_teorema_1_hasta_lema_2_2.tex
+++ b/Memoria/capitulos/2-Articulo_rrnn_aproximadores_universales/desgranando_el_articulo/articulo_2_teorema_1_hasta_lema_2_2.tex
@@ -103,6 +103,17 @@ sin embargo es habitual la combinación de éstas en una misma red neuronal (
  \cite{8258768}, 
  \cite{DBLP:journals/corr/SzegedyVISW15}
 ). 
+%Nota sobre experimentar con 
+%\setlength{\marginparwidth}{\smallMarginSize}
+\reversemarginpar
+\marginpar{\maginLetterSize \iconoProfundizar \textcolor{blue}{\textbf{Nueva hipótesis de optimización}}
+El corolario \ref{cor:se-generaliza-G-a-una-familia}
+abre la puerta a preguntarse si la combinación de diferentes funciones de activación podría mejorar los resultados de alguna manera.
+Abordaremos esta cuestión en \ref{hypothesis:activation-function}.
+}
+\normalmarginpar
+
+\begin{aportacionOriginal}
 
 \begin{corolario}[Pueden combinarse distintas funciones de activación en una misma red neuronal] \label{cor:se-generaliza-G-a-una-familia}
 
@@ -120,21 +131,11 @@ sin embargo es habitual la combinación de éstas en una misma red neuronal (
         \end{split}
     \end{equation}
 \end{corolario}
-
-% Nota sobre experimentar con 
-\setlength{\marginparwidth}{\smallMarginSize}
-\reversemarginpar
-\marginpar{\maginLetterSize \iconoProfundizar \textcolor{blue}{\textbf{Nueva hipótesis de optimización}}
-El corolario \ref{cor:se-generaliza-G-a-una-familia}
-abre la puerta a preguntarse si la combinación de diferentes funciones de activación podría mejorar los resultados de alguna manera.
-Abordaremos esta cuestión en \ref{hypothesis:activation-function}.
-}
-\normalmarginpar
-
 \begin{proof}
     La demostración es idéntica a la dada en el Teorema de convergencia 
     real en compactos \ref{teo:TeoremaConvergenciaRealEnCompactosDefinicionesEsenciales}.
 \end{proof}
+\end{aportacionOriginal}
 
 Notemos que este resultado no da pista alguna de las ventajas de una función frente a otra,
  ni cómo afecta a la \textit{velocidad de convergencia}. 
@@ -143,10 +144,6 @@ Notemos que este resultado no da pista alguna de las ventajas de una función fr
 Recordemos que de manera general se ha definido $A$ como una función afín 
 $A(x) = w \cdot x + b$ donde $x$ y $w$ son vectores de $\R^d$  y $b \in \R$ es un escalar.  ¿Pero que ocurriría si trabajáramos con transformaciones más generales?  
 Por ejemplo $B((x_1, ..., x_d)) = \sum_{i= 0} ^N \sum_{j= 0} ^d \alpha_{ij} x_j^i$  con $N$ natural positivo. 
-
-\begin{corolario}[Generalización de de las transformaciones afines]  \label{corolario:generaliza-a}
-    Se puede extender $\afines$ a conjuntos más generales como el de los polinomios de $d$ variables de grado $N$, $\mathbb{P}$.  
-\end{corolario}
 
 % Nota sobre posible hipótesis de optimización 
 \setlength{\marginparwidth}{\bigMarginSize}
@@ -157,10 +154,15 @@ nos podemos plantear si aumentar el espacio de búsqueda a partir de transformac
 Abordaremos esta cuestión en \ref{hypothesis:activation-function}.
 }
 
-\begin{proof}
-    Simplemente hay que reparar en que $\afines$ está contenido en el espacio $\mathbb{P}$. 
-    Es más observando la demostración bastará con utilizar cualquier conjunto que contenga a $\afines$. 
-\end{proof}
+\begin{aportacionOriginal}
+    \begin{corolario}[Generalización de de las transformaciones afines]  \label{corolario:generaliza-a}
+        Se puede extender $\afines$ a conjuntos más generales como el de los polinomios de $d$ variables de grado $N$, $\mathbb{P}$.  
+    \end{corolario}
+    \begin{proof}
+        Simplemente hay que reparar en que $\afines$ está contenido en el espacio $\mathbb{P}$. 
+        Es más observando la demostración bastará con utilizar cualquier conjunto que contenga a $\afines$. 
+    \end{proof}
+\end{aportacionOriginal}
 
 La utilidad de este corolario a nivel práctico es cuestionable, ya que aumentaría considerablemente el número de 
 parámetros que ajustar de la red neuronal ocasionando: (1) la necesidad de mayor número de datos que aprender, 

--- a/Memoria/capitulos/4-Actualizacion_redes_neuronales/construccion-evaluacion-red-neuronal.tex
+++ b/Memoria/capitulos/4-Actualizacion_redes_neuronales/construccion-evaluacion-red-neuronal.tex
@@ -92,6 +92,8 @@ valores fijados por el diseñador de la red ya que a priori no tenemos otra info
  % Vamos a probar que tampoco mejora el error 
 \subsection{Consideraciones sobre la irrelevancia del sesgo}
 
+\begin{aportacionOriginal}
+
  Dados $X \subseteq \R^d, Y \subseteq \R^s$ y  $\Gamma$ un conjunto no vacío de funciones medibles definidas de $\R$ a $\R$, denotaremos como $\mathcal{H}^+(X,Y)$ al conjunto de redes neuronales a las cuales se le ha añadido un sesgo. 
 
 \begin{align}
@@ -186,6 +188,9 @@ Tomando tan solo dos puntos convenientemente seleccionados se llega a la contrad
  Concluimos tras todo esto que aunque la precisión que se pueda obtener con funciones de $\mathcal{H}_n(X,Y)$ y $\mathcal{H}^+_n(X,Y)$ es diferente para un mismo número de neuronas $n$, añadiendo una más el sesgo es irrelevante  y además $\mathcal{H}^+_n(X,Y)$ tiene mayor coste computacional, por lo que afirmamos que 
 que es un artificio de las redes neuronales multicapa para enlazar una capa con otra y que en redes neuronales de una capa oculta carece de sentido.
 
+\end{aportacionOriginal} % fin aportación original irrelevancia del sesgo
+
+
 % Consideración sobre componer la red neuronal con una función
 \subsection{\textit{Modus operandi} ante problemas que requieran un dominio de salida discreto}
 
@@ -218,6 +223,8 @@ $h \in \rrnnmc$ tal que $h$ aproxime a $\theta^{-1} \circ f$.
 
 Lo cual esto exige que $\theta$ tenga inversa y que sea medible, además de la cuestión de qué $\theta$ es la más conveniente $\dots$
 
+\begin{aportacionOriginal} % aportación original salida discreta
+    
 Es por ello que en nuestra aproximación descartamos este modo de proceder y proponemos el siguiente: 
 
 \begin{enumerate}
@@ -241,6 +248,8 @@ El motivo por el que se ha optado por esta aproximación es que si consideráram
 \end{equation}
 
 Donde $I_y$ puede no ser un intervalo conexo y que introduciría complejidad al cálculo y determinación de $\tilde{\theta}$, es por ello que lo natural sería entonces construir un función que discretice a partir de los valores conocidos más cercanos, esto es el algoritmo $k-$NN.  
+
+\end{aportacionOriginal}  % aportación original salida discreta
 
 \subsubsection*{Construcción de $k-$NN}  
 

--- a/Memoria/capitulos/4-Actualizacion_redes_neuronales/optimizaciones.tex
+++ b/Memoria/capitulos/4-Actualizacion_redes_neuronales/optimizaciones.tex
@@ -20,6 +20,8 @@ que este algoritmo permitiría generar nuestro propio backbone}
 
 \subsection{Descripción del método propuesto}
 
+\begin{aportacionOriginal} % método de construción
+    
 La idea proviene de la demostración casi constructiva del teorema \ref{teorema:2_5_entrenamiento_redes_neuronales}.
 
 Se desea inicializar los peso de $h \in \rrnnsmn$, para la cual, una vez fijado el número $n$ de neuronas de nuestra red neuronal, será necesario  determinar un subconjunto $\Lambda \mathcal{D}$ de datos de entrenamiento. 
@@ -136,6 +138,8 @@ cuya solución son las respectivas filas y columnas:
 \end{equation}  
 
 Con todo esto el proceso algorítmico resultante es: 
+
+\end{aportacionOriginal} % método de construción
 
 % Algoritmo de inicialización de pesos de una red neuronal
 

--- a/Memoria/paquetes/comandos-entornos.tex
+++ b/Memoria/paquetes/comandos-entornos.tex
@@ -131,7 +131,7 @@ backgroundcolor=black!7,
 
 \newenvironment{aportacionOriginal}
   {\mdfsetup{
-    frametitle={\colorbox{black!7}{ \textcolor{white}{Aportación original}}},
+    frametitle={\colorbox{black!7}{ \textcolor{white}{\Large Aportación original}}},
     %frametitleaboveskip=-\ht\strutbox,
     %frametitlealignment=\center
     }

--- a/Memoria/paquetes/comandos-entornos.tex
+++ b/Memoria/paquetes/comandos-entornos.tex
@@ -100,3 +100,43 @@
 % blue
 \newcommand{\iconoProfundizar}{\faSearch  $\quad$}
 \newcommand{\iconoClave}{\faLightbulbO  $\quad$} % \faLightbulbO %\faKey
+
+% Contenido original 
+\usepackage{lipsum}
+\usepackage[%
+linewidth=5pt,
+outerlinecolor=red,
+outerlinewidth=5pt,
+innerlinewidth=0pt,
+outerlinecolor=red,
+roundcorner=5pt
+%middlelinecolor= yellow,
+middlelinewidth=0.4pt,
+%roundcorner=1pt,
+topline = false,
+rightline = false,
+leftline = false,
+bottomline = false,
+rightmargin=0pt,
+skipabove=0pt,
+skipbelow=0pt,
+leftmargin=-1cm,
+backgroundcolor=black!7,
+%innerleftmargin=1cm,
+%innerrightmargin=0pt,
+%innertopmargin=0pt,
+%innerbottommargin=0pt,
+%frametitlebackgroundcolor=yellow,
+]{mdframed}
+
+\newenvironment{aportacionOriginal}
+  {\mdfsetup{
+    frametitle={\colorbox{black!7}{ \textcolor{white}{Aportación original}}},
+    %frametitleaboveskip=-\ht\strutbox,
+    %frametitlealignment=\center
+    }
+  \begin{mdframed}%
+  }
+  {\end{mdframed}}
+
+


### PR DESCRIPTION
Se aporta una forma de destacar visualmente el contenido original por lo que  closes #91 

Estoy abierta a nuevas sugerencia, el resultado visual es el siguiente: 
<img width="1512" alt="Captura de Pantalla 2022-05-15 a las 10 28 30" src="https://user-images.githubusercontent.com/32298296/168464586-5d7305c6-49cf-4d35-87f7-42f0af0a16b4.png">

Cabe destacar las siguientes decisiones: 

1. No he destacado los resultados que son consecuencia de las aportaciones originales, porque me daba la sensación que era demasiado destacar regiones. Pongo un ejemplo de a lo que me refiero: 
Una aportación original es el modelo que proponemos, pero no destaco como original el algoritmo de evaluación que se deduce él o su análisis en coste.

2. No he destacado como original las correcciones a erratas del artículo de convergencia o algunas que directamente enfoqué de manera distinta ¿Debiera de hacerlo?
