### PR TITLE
Las mayúsculas de acrónimos tienen que protegerse

### DIFF
--- a/Memoria/library.bib
+++ b/Memoria/library.bib
@@ -828,7 +828,7 @@ issue_date = {Nov. 1994},
 % sobre cómo hacer un TFG
 @online{que-es-un-trabajo-fin-de-x,
   author= {Juan Juli{\'{a}}n Merelo Guerv{\'{o}}s},
-  title ={Cómo llevar a término un TFG/TFM en informática},
+  title ={{Cómo llevar a término un TFG/TFM en informática}},
   url = {https://jj.github.io/que-es-un-trabajo-fin-de-x/tf.html},
   urldate = {2022-02-05}
 }


### PR DESCRIPTION

![Captura de pantalla de 2022-06-20 14-29-38](https://user-images.githubusercontent.com/500/174601881-3d519425-cf6f-4cb6-92ca-3deddfc7c389.png)
O si no, BiBTex las pasa a minúsculas